### PR TITLE
Cors origin fix

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -7,7 +7,9 @@ const { Pool } = require("pg");
 
 dotenv.config();
 const app = express();
-app.use(cors());
+app.use(cors({
+  origin: ["https://surgitrack.vercel.app", "http://localhost:5173"]
+}));
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 


### PR DESCRIPTION
add production frontend domain to cors origin whitelist to allow api request from surgitrack.vercel.app to surgitrack-backend.vercel.app