### PR TITLE
Add SSE subscription for real-time Status Board updates

### DIFF
--- a/client/src/pages/PatientStatus.jsx
+++ b/client/src/pages/PatientStatus.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import SimpleTable from "../components/SimpleTable"
 import { createRow } from "../components/CreateRow";
 import StatusFlowGuide from "../components/StatusFlowGuide";
-import { getAllPatients } from "../service/apiServicePatient";
+import { getAllPatients, subscribePatientUpdates } from "../service/apiServicePatient";
 
 export default function PatientStatus(){
      // Table columns configuration.
@@ -12,25 +12,6 @@ export default function PatientStatus(){
   ];  
   
   const [patients, setPatients] = useState([]);
-
-  // Option for refreshing the GET every 5 seconds
-  // const fetchPatients = async () => {
-  //     try {
-  //       const data = await getAllPatients();
-  //       console.log("Fetched patients:", data);
-  //       data.sort((a, b) => (a.patient_id > b.patient_id ? 1 : -1));
-  //       setPatients(data);
-  //     } catch (err) {
-  //       console.error("Fetch error:", err);
-  //     }
-  //   };
-
-  //   useEffect(() => {
-  //   fetchPatients(); // Initial fetch
-  //   const interval = setInterval(fetchPatients, 5000); // Poll every 5s
-
-  //   return () => clearInterval(interval); // Cleanup on unmount
-  // }, []);
 
   useEffect(() => {
     const fetchPatients = async () => {
@@ -44,7 +25,20 @@ export default function PatientStatus(){
       }
     };
     fetchPatients();
-  }, []);
+    
+  // SSE subscription
+    const es = subscribePatientUpdates((updatedPatient) => {
+    setPatients((prevPatients) =>
+      prevPatients.map((p) =>
+        p.patient_number === updatedPatient.patient_number
+          ? updatedPatient
+          : p
+      )
+    );
+  });
+
+  return () => es.close(); 
+}, []);
 
   const filteredPatients = patients
   .filter((p) => {

--- a/client/src/service/apiServicePatient.jsx
+++ b/client/src/service/apiServicePatient.jsx
@@ -10,3 +10,28 @@ export const getAllPatients = async () => {
     throw Error(`Error fetching patients: ${error.message}`);
   }
 }
+
+// ================= SSE Subscription =================
+export const subscribePatientUpdates = (onUpdate) => {
+  const eventSource = new EventSource(`${patientsApiUrl}/events`);
+
+  eventSource.onopen = () => console.log("SSE connected");
+  
+  eventSource.onmessage = (event) => {
+    try {
+      const updatedPatient = JSON.parse(event.data);
+      console.log("SSE update received:", updatedPatient);
+      onUpdate(updatedPatient); 
+    } catch (err) {
+      console.error("Error parsing SSE message:", err);
+    }
+  };
+
+  eventSource.onerror = (err) => {
+    console.error("SSE error", err);
+    eventSource.close();
+  };
+
+  // Return the EventSource so the component can close it on unmount
+  return eventSource;
+};


### PR DESCRIPTION
Implemented Server-Sent Events (SSE) subscription to automatically refresh the Status Board whenever a patient’s status changes in the backend. 

This ensures that updates are reflected in real time, whether the status change is triggered from:

- The Patient Status Update Page
- Postman
- Any other backend process

This eliminates the need for manual refresh or automatic refresh every 5 seconds and keeps the Status Board always up to date.